### PR TITLE
Fix Wireless Terminals hotkey

### DIFF
--- a/src/main/java/com/_0xc4de/ae2exttable/client/KeyBindings.java
+++ b/src/main/java/com/_0xc4de/ae2exttable/client/KeyBindings.java
@@ -13,7 +13,7 @@ public enum KeyBindings {
     elite(new KeyBinding("key.open_elite_extended_wireless_crafting_terminal", KeyConflictContext.UNIVERSAL, KeyModifier.NONE, Keyboard.KEY_NONE, KEY_CATEGORY)),
     ultimate(new KeyBinding("key.open_ultimate_extended_wireless_crafting_terminal", KeyConflictContext.UNIVERSAL, KeyModifier.NONE, Keyboard.KEY_NONE, KEY_CATEGORY));
 
-    private KeyBinding binding;
+    private final KeyBinding binding;
 
     KeyBindings(KeyBinding keyBinding) {
         this.binding = keyBinding;

--- a/src/main/java/com/_0xc4de/ae2exttable/client/container/ContainerSharedWirelessTerminals.java
+++ b/src/main/java/com/_0xc4de/ae2exttable/client/container/ContainerSharedWirelessTerminals.java
@@ -13,7 +13,6 @@ import appeng.util.Platform;
 import appeng.util.inv.IAEAppEngInventory;
 import appeng.util.inv.WrapperInvItemHandler;
 import baubles.api.BaublesApi;
-import com._0xc4de.ae2exttable.client.gui.AE2ExtendedGUIs;
 import com._0xc4de.ae2exttable.client.gui.ExtendedCraftingGUIConstants;
 import com._0xc4de.ae2exttable.client.gui.WirelessTerminalGuiObjectTwo;
 import net.minecraft.entity.player.EntityPlayer;
@@ -52,8 +51,8 @@ public class ContainerSharedWirelessTerminals extends ContainerMEMonitorableTwo
 
     if (guiItemObject != null) {
       final int slotIndex =
-          ((IInventorySlotAware) guiItemObject).getInventorySlot();
-      if (!((IInventorySlotAware) guiItemObject).isBaubleSlot()) {
+          guiItemObject.getInventorySlot();
+      if (!guiItemObject.isBaubleSlot()) {
         this.lockPlayerInventorySlot(slotIndex);
       }
       this.slot = slotIndex;

--- a/src/main/java/com/_0xc4de/ae2exttable/client/gui/PartGuiHandler.java
+++ b/src/main/java/com/_0xc4de/ae2exttable/client/gui/PartGuiHandler.java
@@ -9,20 +9,14 @@ import appeng.api.AEApi;
 import appeng.api.features.ILocatable;
 import appeng.api.features.IWirelessTermHandler;
 import appeng.api.features.IWirelessTermRegistry;
-import appeng.api.networking.IGrid;
-import appeng.api.networking.storage.IStorageGrid;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
-import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.ITerminalHost;
-import appeng.api.storage.channels.IItemStorageChannel;
-import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.AEPartLocation;
 import appeng.container.AEBaseContainer;
 import appeng.container.ContainerOpenContext;
 import appeng.core.localization.PlayerMessages;
 import appeng.me.GridAccessException;
-import appeng.tile.misc.TileSecurityStation;
 import appeng.util.Platform;
 import baubles.api.BaublesApi;
 import com._0xc4de.ae2exttable.AE2ExtendedCraftingTable;
@@ -52,6 +46,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.common.network.IGuiHandler;
 import org.jetbrains.annotations.Nullable;
 
@@ -90,13 +86,8 @@ public class PartGuiHandler implements IGuiHandler {
             return;
         }
         final long parsedKey = Long.parseLong(unparsedKey);
-        final ILocatable
-                securityStation =
+        final ILocatable securityStation =
                 AEApi.instance().registries().locatable().getLocatableBy(parsedKey);
-        TileSecurityStation security_station = (TileSecurityStation) securityStation;
-        IGrid grid = security_station.getProxy().getGrid();
-        IStorageGrid inv = grid.getCache(IStorageGrid.class);
-        final IMEMonitor<IAEItemStack> storage = inv.getInventory(AEApi.instance().storage().getStorageChannel(IItemStorageChannel.class));
         if (securityStation == null) {
             player.sendMessage(PlayerMessages.StationCanNotBeLocated.get());
             return;
@@ -140,8 +131,7 @@ public class PartGuiHandler implements IGuiHandler {
     private Object updateGui(final Object newContainer, final World w,
                              final int x, final int y, final int z,
                              final AEPartLocation side, final Object myItem) {
-        if (newContainer instanceof AEBaseContainer) {
-            final AEBaseContainer bc = (AEBaseContainer) newContainer;
+        if (newContainer instanceof AEBaseContainer bc) {
             bc.setOpenContext(new ContainerOpenContext(myItem));
             bc.getOpenContext().setWorld(w);
             bc.getOpenContext().setX(x);
@@ -163,11 +153,9 @@ public class PartGuiHandler implements IGuiHandler {
 
         if (guiIsWirelessTerminal(guiID)) { // idk is item
             ItemStack termItem = getWirelessTermItem(usingItemOnTile, player, world, guiID, side, x, y, z);
-            final Object item =
-                    this.getGuiObject(guiID, termItem, player, world, x, y, z, side);
+            final Object item = this.getGuiObject(guiID, termItem, player, world, x, y, z, side);
             return this.updateGui(item, world, x, y, z, side, termItem);
         } else {
-
             final TileEntity TE = world.getTileEntity(new BlockPos(x, y, z));
 
             if (TE instanceof IPartHost) {
@@ -175,9 +163,7 @@ public class PartGuiHandler implements IGuiHandler {
                 if (part == null) {
                     return null;
                 }
-                Object gui =
-                        this.getGuiObject(guiID, ItemStack.EMPTY, player, world, x, y, z,
-                                side);
+                Object gui = this.getGuiObject(guiID, ItemStack.EMPTY, player, world, x, y, z, side);
                 return this.updateGui(gui, world, x, y, z, side, part);
             }
         }
@@ -193,8 +179,7 @@ public class PartGuiHandler implements IGuiHandler {
                                 final int z, final AEPartLocation side) {
 
         if (myItem.isEmpty()) {
-            IPart part =
-                    PartGuiHandler.getPartFromWorld(world, new BlockPos(x, y, z), side);
+            IPart part = PartGuiHandler.getPartFromWorld(world, new BlockPos(x, y, z), side);
 
             return switch (guiID) {
                 case BASIC_CRAFTING_TERMINAL -> new ContainerBasicCraftingTerminal(player.inventory,
@@ -214,19 +199,15 @@ public class PartGuiHandler implements IGuiHandler {
                         AEApi.instance().registries().wireless()
                                 .getWirelessTerminalHandler(myItem);
 
-                wireless =
-                        new WirelessTerminalGuiObjectTwo(handler, myItem, player, world, x,
-                                y, z);
+                wireless = new WirelessTerminalGuiObjectTwo(handler, myItem, player, world, x, y, z);
             }
 
             return switch (guiID) {
                 // Start wireless stuffs here
                 case WIRELESS_BASIC_CRAFTING_TERMINAL -> new ContainerBasicWirelessTerminal(player.inventory, wireless);
-                case WIRELESS_ADVANCED_CRAFTING_TERMINAL ->
-                        new ContainerAdvancedWirelessTerminal(player.inventory, wireless);
+                case WIRELESS_ADVANCED_CRAFTING_TERMINAL -> new ContainerAdvancedWirelessTerminal(player.inventory, wireless);
                 case WIRELESS_ELITE_CRAFTING_TERMINAL -> new ContainerEliteWirelessTerminal(player.inventory, wireless);
-                case WIRELESS_ULTIMATE_CRAFTING_TERMINAL ->
-                        new ContainerUltimateWirelessTerminal(player.inventory, wireless);
+                case WIRELESS_ULTIMATE_CRAFTING_TERMINAL -> new ContainerUltimateWirelessTerminal(player.inventory, wireless);
                 default -> null;
             };
         }
@@ -238,66 +219,62 @@ public class PartGuiHandler implements IGuiHandler {
                                                 int z) {
         AE2ExtendedGUIs guiID = PartGuiHandler.getGUIFromOrdinal(ID);
         AEPartLocation side = PartGuiHandler.getSideFromOrdinal(ID);
-        IPart part =
-                PartGuiHandler.getPartFromWorld(world, new BlockPos(x, y, z), side);
         final boolean usingItemOnTile = ((ID >> 3) & 1) == 1;
 
         WirelessTerminalGuiObjectTwo gui = null;
+        ITerminalHost part = null;
         if (guiIsWirelessTerminal(guiID)) {
             ItemStack termItem = getWirelessTermItem(usingItemOnTile, player, world, guiID, side, x, y, z);
             final IWirelessTermHandler handler =
                     AEApi.instance().registries().wireless()
                             .getWirelessTerminalHandler(termItem);
-            gui = new WirelessTerminalGuiObjectTwo(
-                    handler, player.inventory.getCurrentItem(), player, world, x, y, z);
+
+            ItemStack terminal = ItemStack.EMPTY;
+            if (y == 0) {
+                terminal = player.inventory.getStackInSlot(x);
+            } else if (y == 1 && Loader.isModLoaded("baubles")) {
+                terminal = getStackInBaubleSlot(player, x);
+            }
+
+            if (terminal.isEmpty())return null;
+
+            gui = new WirelessTerminalGuiObjectTwo(handler, terminal, player, world, x, y, z);
+        } else {
+            part = (ITerminalHost)PartGuiHandler.getPartFromWorld(world, new BlockPos(x, y, z), side);
         }
 
-        switch (guiID) {
-            case BASIC_CRAFTING_TERMINAL:
-                GuiBasicCraftingTerminal term =
-                        new GuiBasicCraftingTerminal(player.inventory, (ITerminalHost) part,
-                                new ContainerBasicCraftingTerminal(player.inventory,
-                                        (PartBasicCraftingTerminal) part));
-                return term;
-            case ADVANCED_CRAFTING_TERMINAL:
-                return new GuiAdvancedCraftingTerminal(player.inventory,
-                        (ITerminalHost) part,
-                        new ContainerAdvancedCraftingTerminal(player.inventory,
-                                (PartAdvancedCraftingTerminal) part));
-            case ELITE_CRAFTING_TERMINAL:
-                return new GuiEliteCraftingTerminal(player.inventory,
-                        (ITerminalHost) part,
-                        new ContainerEliteCraftingTerminal(player.inventory,
-                                (PartEliteCraftingTerminal) part));
-            case ULTIMATE_CRAFTING_TERMINAL:
-                return new GuiUltimateCraftingTerminal(player.inventory,
-                        (ITerminalHost) part,
-                        new ContainerUltimateCraftingTerminal(player.inventory,
-                                (PartUltimateCraftingTerminal) part));
+        return switch (guiID) {
+            case BASIC_CRAFTING_TERMINAL -> new GuiBasicCraftingTerminal(player.inventory, part,
+                    new ContainerBasicCraftingTerminal(
+                            player.inventory, part));
+            case ADVANCED_CRAFTING_TERMINAL -> new GuiAdvancedCraftingTerminal(player.inventory, part,
+                    new ContainerAdvancedCraftingTerminal(
+                            player.inventory, part));
+            case ELITE_CRAFTING_TERMINAL -> new GuiEliteCraftingTerminal(player.inventory, part,
+                    new ContainerEliteCraftingTerminal(
+                            player.inventory, part));
+            case ULTIMATE_CRAFTING_TERMINAL -> new GuiUltimateCraftingTerminal(player.inventory, part,
+                    new ContainerUltimateCraftingTerminal(
+                            player.inventory, part));
+            case WIRELESS_BASIC_CRAFTING_TERMINAL ->
+                    new GuiWirelessBasicCraftingTerm(player.inventory, gui,
+                            new ContainerBasicWirelessTerminal(
+                                    player.inventory, gui));
+            case WIRELESS_ADVANCED_CRAFTING_TERMINAL -> new GuiWirelessAdvancedCraftingTerm(player.inventory, gui,
+                    new ContainerAdvancedWirelessTerminal(player.inventory, gui));
+            case WIRELESS_ELITE_CRAFTING_TERMINAL -> new GuiWirelessEliteCraftingTerm(player.inventory, gui,
+                    new ContainerEliteWirelessTerminal(
+                            player.inventory, gui));
+            case WIRELESS_ULTIMATE_CRAFTING_TERMINAL -> new GuiWirelessUltimateCraftingTerm(player.inventory, gui,
+                    new ContainerUltimateWirelessTerminal(
+                            player.inventory, gui));
+            default -> null;
+        };
+    }
 
-            case WIRELESS_BASIC_CRAFTING_TERMINAL:
-                // TODO: Fix for baubles, I guess?
-                return new GuiWirelessBasicCraftingTerm(player.inventory, gui,
-                        new ContainerBasicWirelessTerminal(
-                                player.inventory, gui));
-
-            case WIRELESS_ADVANCED_CRAFTING_TERMINAL:
-                return new GuiWirelessAdvancedCraftingTerm(player.inventory, gui,
-                        new ContainerAdvancedWirelessTerminal(
-                                player.inventory, gui));
-
-            case WIRELESS_ELITE_CRAFTING_TERMINAL:
-                return new GuiWirelessEliteCraftingTerm(player.inventory, gui,
-                        new ContainerEliteWirelessTerminal(
-                                player.inventory, gui));
-
-            case WIRELESS_ULTIMATE_CRAFTING_TERMINAL:
-                return new GuiWirelessUltimateCraftingTerm(player.inventory, gui,
-                        new ContainerUltimateWirelessTerminal(
-                                player.inventory, gui));
-            default:
-                return null;
-        }
+    @Optional.Method(modid = "baubles")
+    private ItemStack getStackInBaubleSlot(EntityPlayer player,int slot){
+        return slot >= 0 && slot < BaublesApi.getBaublesHandler(player).getSlots() ? BaublesApi.getBaublesHandler(player).getStackInSlot(slot) : ItemStack.EMPTY;
     }
 
     private ItemStack getWirelessTermItem(boolean usingItemOnTile, EntityPlayer player, World world, AE2ExtendedGUIs guiID, AEPartLocation side, int x, int y, int z) {
@@ -313,8 +290,6 @@ public class PartGuiHandler implements IGuiHandler {
         }
         return termItem;
     }
-
-    ;
 
     public static boolean guiIsWirelessTerminal(AE2ExtendedGUIs gui) {
         return gui.ordinal() > 4;

--- a/src/main/java/com/_0xc4de/ae2exttable/network/packets/PacketOpenWirelessGui.java
+++ b/src/main/java/com/_0xc4de/ae2exttable/network/packets/PacketOpenWirelessGui.java
@@ -1,16 +1,12 @@
 package com._0xc4de.ae2exttable.network.packets;
 
-import appeng.api.networking.security.IActionHost;
-import appeng.container.AEBaseContainer;
-import appeng.container.ContainerOpenContext;
-import appeng.container.interfaces.IInventorySlotAware;
 import appeng.core.sync.network.INetworkInfo;
 import appeng.me.GridAccessException;
 import appeng.util.Platform;
 import baubles.api.BaublesApi;
 import com._0xc4de.ae2exttable.client.gui.AE2ExtendedGUIs;
 import com._0xc4de.ae2exttable.client.gui.PartGuiHandler;
-import com._0xc4de.ae2exttable.items.ItemRegistry;
+import com._0xc4de.ae2exttable.interfaces.ITerminalGui;
 import com._0xc4de.ae2exttable.network.ExtendedTerminalPacket;
 import com._0xc4de.ae2exttable.network.PacketHandler;
 import io.netty.buffer.ByteBuf;
@@ -18,49 +14,53 @@ import io.netty.buffer.Unpooled;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-
+import net.minecraftforge.fml.common.Optional;
 
 public class PacketOpenWirelessGui extends ExtendedTerminalPacket {
 
-  private final AE2ExtendedGUIs gui;
+    private final AE2ExtendedGUIs gui;
 
-  public PacketOpenWirelessGui(final ByteBuf stream) {
-    this.gui = AE2ExtendedGUIs.values()[stream.readInt()];
-  }
+    public PacketOpenWirelessGui(final ByteBuf stream) {
+        this.gui = AE2ExtendedGUIs.values()[stream.readInt()];
+    }
 
-  public PacketOpenWirelessGui(final AE2ExtendedGUIs gui) {
-    this.gui = gui;
-    final ByteBuf data = Unpooled.buffer();
-    data.writeInt(this.getGuiPacketID());
-    data.writeInt(gui.ordinal());
+    public PacketOpenWirelessGui(final AE2ExtendedGUIs gui) {
+        this.gui = gui;
+        final ByteBuf data = Unpooled.buffer();
+        data.writeInt(this.getGuiPacketID());
+        data.writeInt(gui.ordinal());
 
-    this.configureWrite(data);
-  }
+        this.configureWrite(data);
+    }
 
-  public int getGuiPacketID() {
-    return PacketHandler.PacketTypes.getID(this.getClass()).ordinal();
-  }
+    public int getGuiPacketID() {
+        return PacketHandler.PacketTypes.getID(this.getClass()).ordinal();
+    }
 
-  @Override
-  public void serverPacketData(final INetworkInfo manager,
-                               final ExtendedTerminalPacket packet,
-                               final EntityPlayer player) throws GridAccessException {
+    @Override
+    public void serverPacketData(final INetworkInfo manager,
+                                 final ExtendedTerminalPacket packet,
+                                 final EntityPlayer player) throws GridAccessException {
         NonNullList<ItemStack> inventory = player.inventory.mainInventory;
-        ItemStack guiItem = new ItemStack(ItemRegistry.partByGuiType(this.gui));
         for (int i = 0; i < inventory.size(); i++) {
             ItemStack is = inventory.get(i);
-            if (Platform.itemComparisons().isEqualItemType(is, guiItem)) {
+            if (is.getItem() instanceof ITerminalGui wt && wt.getGuiType() == this.gui) {
                 openGui(is, i, player, false);
                 return;
             }
         }
         if (Platform.isModLoaded("baubles")) {
-            for (int i = 0; i< BaublesApi.getBaublesHandler(player).getSlots(); i++) {
-                ItemStack is = BaublesApi.getBaublesHandler(player).getStackInSlot(i);
-                if (Platform.itemComparisons().isEqualItemType(is, guiItem)) {
-                  openGui(is, i, player, true);
-                  return;
-                }
+            tryOpenBauble(player);
+        }
+    }
+
+    @Optional.Method(modid = "baubles")
+    private void tryOpenBauble(EntityPlayer player) throws GridAccessException {
+        for (int i = 0; i < BaublesApi.getBaublesHandler(player).getSlots(); i++) {
+            ItemStack is = BaublesApi.getBaublesHandler(player).getStackInSlot(i);
+            if (is.getItem() instanceof ITerminalGui wt && wt.getGuiType() == this.gui) {
+                openGui(is, i, player, true);
+                return;
             }
         }
     }

--- a/src/main/java/com/_0xc4de/ae2exttable/part/ExtInternalInventory.java
+++ b/src/main/java/com/_0xc4de/ae2exttable/part/ExtInternalInventory.java
@@ -13,6 +13,7 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 
 import net.minecraftforge.common.util.INBTSerializable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Manages an internal inventory
@@ -57,12 +58,12 @@ public class ExtInternalInventory implements IInventory, INBTSerializable<NBTTag
     }
 
     @Override
-    public ItemStack getStackInSlot(int index) {
+    public @NotNull ItemStack getStackInSlot(int index) {
         return this.slots.get(index);
     }
 
     @Override
-    public ItemStack decrStackSize(int index, int count) {
+    public @NotNull ItemStack decrStackSize(int index, int count) {
         ItemStack stack = this.getStackInSlot(index);
         if (stack.isEmpty())
             return stack;
@@ -72,11 +73,11 @@ public class ExtInternalInventory implements IInventory, INBTSerializable<NBTTag
     }
 
     @Override
-    public ItemStack removeStackFromSlot(int index) {
+    public @NotNull ItemStack removeStackFromSlot(int index) {
         ItemStack stack = this.getStackInSlot(index);
         this.setInventorySlotContents(index, ItemStack.EMPTY);
         this.markDirty();
-        return stack != null ? stack : ItemStack.EMPTY;
+        return stack;
     }
 
     @Override
@@ -98,22 +99,22 @@ public class ExtInternalInventory implements IInventory, INBTSerializable<NBTTag
     }
 
     @Override
-    public boolean isUsableByPlayer(EntityPlayer player) {
+    public boolean isUsableByPlayer(@NotNull EntityPlayer player) {
         return true;
     }
 
     @Override
-    public void openInventory(EntityPlayer player) {
+    public void openInventory(@NotNull EntityPlayer player) {
 
     }
 
     @Override
-    public void closeInventory(EntityPlayer player) {
+    public void closeInventory(@NotNull EntityPlayer player) {
 
     }
 
     @Override
-    public boolean isItemValidForSlot(int index, ItemStack stack) {
+    public boolean isItemValidForSlot(int index, @NotNull ItemStack stack) {
         return true;
     }
 
@@ -138,7 +139,7 @@ public class ExtInternalInventory implements IInventory, INBTSerializable<NBTTag
     }
 
     @Override
-    public String getName() {
+    public @NotNull String getName() {
         return this.customName;
     }
 
@@ -148,7 +149,7 @@ public class ExtInternalInventory implements IInventory, INBTSerializable<NBTTag
     }
 
     @Override
-    public ITextComponent getDisplayName() {
+    public @NotNull ITextComponent getDisplayName() {
         return new TextComponentString(this.getName());
     }
 
@@ -167,7 +168,7 @@ public class ExtInternalInventory implements IInventory, INBTSerializable<NBTTag
     }
 
     @Override
-    public Iterator<ItemStack> iterator() {
+    public @NotNull Iterator<ItemStack> iterator() {
         return Collections.unmodifiableCollection(this.slots).iterator();
     }
 }

--- a/src/main/java/com/_0xc4de/ae2exttable/proxy/ClientProxy.java
+++ b/src/main/java/com/_0xc4de/ae2exttable/proxy/ClientProxy.java
@@ -4,7 +4,6 @@ import com._0xc4de.ae2exttable.client.KeyBindings;
 import com._0xc4de.ae2exttable.items.ItemRegistry;
 import com._0xc4de.ae2exttable.network.ExtendedTerminalNetworkHandler;
 import com._0xc4de.ae2exttable.network.packets.PacketOpenWirelessGui;
-import com._0xc4de.ae2exttable.network.packets.PacketSwitchGui;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
@@ -14,7 +13,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
 
 import static com._0xc4de.ae2exttable.client.gui.AE2ExtendedGUIs.*;
-import static com._0xc4de.ae2exttable.client.gui.AE2ExtendedGUIs.ULTIMATE_CRAFTING_TERMINAL;
 
 public class ClientProxy extends CommonProxy {
     public static String KEY_CATEGORY = "key.ae2exttable.category";
@@ -44,8 +42,7 @@ public class ClientProxy extends CommonProxy {
             if (k.get().isPressed()) {
                 if (k.get() == KeyBindings.basic.get()) {
                     ExtendedTerminalNetworkHandler.instance().sendToServer(new PacketOpenWirelessGui(WIRELESS_BASIC_CRAFTING_TERMINAL));
-                }
-                else if (k.get() == KeyBindings.advanced.get()) {
+                } else if (k.get() == KeyBindings.advanced.get()) {
                     ExtendedTerminalNetworkHandler.instance().sendToServer(new PacketOpenWirelessGui(WIRELESS_ADVANCED_CRAFTING_TERMINAL));
                 } else if (k.get() == KeyBindings.elite.get()) {
                     ExtendedTerminalNetworkHandler.instance().sendToServer(new PacketOpenWirelessGui(WIRELESS_ELITE_CRAFTING_TERMINAL));

--- a/src/main/resources/assets/ae2exttable/lang/zh_cn.lang
+++ b/src/main/resources/assets/ae2exttable/lang/zh_cn.lang
@@ -6,24 +6,24 @@ key.open_advanced_extended_wireless_crafting_terminal=打开无线高级合成�
 key.open_elite_extended_wireless_crafting_terminal=打开无线精英合成终端
 key.open_ultimate_extended_wireless_crafting_terminal=打开无线终极合成终端
 
-container.ae2exttable.custom_extended_table.name=更酷的扩展合成台
-tile.ae2exttable.custom_extended_table.name=更酷的扩展合成台
+container.ae2exttable.custom_extended_table.name=更酷的拓展合成台
+tile.ae2exttable.custom_extended_table.name=更酷的拓展合成台
 container.ae2exttable.custom_extended_table=更酷的合成
-tooltip.ae2exttable.custom_extended_table=毕竟原版扩展合成台还不够酷
+tooltip.ae2exttable.custom_extended_table=毕竟原版拓展合成台还不够酷
 
-item.ae2exttable.basic_crafting_terminal.name=基础扩展合成终端
+item.ae2exttable.basic_crafting_terminal.name=基础拓展合成终端
 ae2exttable.basic_crafting_terminal=终端
 ae2exttable.basic_crafting_terminal.crafting=基础合成
 
-item.ae2exttable.advanced_crafting_terminal.name=高级扩展合成终端
+item.ae2exttable.advanced_crafting_terminal.name=高级拓展合成终端
 ae2exttable.advanced_crafting_terminal=终端
 ae2exttable.advanced_crafting_terminal.crafting=高级合成
 
-item.ae2exttable.elite_crafting_terminal.name=精英扩展合成终端
+item.ae2exttable.elite_crafting_terminal.name=精英拓展合成终端
 ae2exttable.elite_crafting_terminal=终端
 ae2exttable.elite_crafting_terminal.crafting=精英合成
 
-item.ae2exttable.ultimate_crafting_terminal.name=终极扩展合成终端
+item.ae2exttable.ultimate_crafting_terminal.name=终极拓展合成终端
 ae2exttable.ultimate_crafting_terminal=终端
 ae2exttable.ultimate_crafting_terminal.crafting=终极合成
 

--- a/src/main/resources/assets/ae2exttable/lang/zh_cn.lang
+++ b/src/main/resources/assets/ae2exttable/lang/zh_cn.lang
@@ -1,4 +1,10 @@
-itemGroup.ae2exttable=AE2扩展合成台
+itemGroup.ae2exttable=AE2拓展工作台
+key.ae2exttable.category=AE2拓展工作台
+
+key.open_basic_extended_wireless_crafting_terminal=打开无线基础合成终端
+key.open_advanced_extended_wireless_crafting_terminal=打开无线高级合成终端
+key.open_elite_extended_wireless_crafting_terminal=打开无线精英合成终端
+key.open_ultimate_extended_wireless_crafting_terminal=打开无线终极合成终端
 
 container.ae2exttable.custom_extended_table.name=更酷的扩展合成台
 tile.ae2exttable.custom_extended_table.name=更酷的扩展合成台


### PR DESCRIPTION
 - Now they can be correctly opened, not just when the Wireless Terminals are held in hand.
 - Now they can also function properly when in the Baubles.
 
Also adjusted the working method to avoid reliance on Baubles.

Although my tests didn't show any issues, it's still advisable to conduct a second test.